### PR TITLE
Update show_crypto.py

### DIFF
--- a/src/genie/libs/parser/iosxe/show_crypto.py
+++ b/src/genie/libs/parser/iosxe/show_crypto.py
@@ -6101,13 +6101,13 @@ class ShowCryptoIkev2Sa(ShowCryptoIkev2SaSchema):
         ret_dict = {}
 
         # IPv4 Crypto IKEv2  SA  
-        p1 = re.compile(r'^IPv4 Crypto IKEv2 SA$')
+        p1 = re.compile(r'^IPv4 Crypto IKEv2\s+SA$')
 
         # IPv6 Crypto IKEv2  SA 
         p2 = re.compile(r'^IPv6 Crypto IKEv2 SA$')
 
         # 1         66.66.66.1/500        66.66.66.2/500        none/none            READY
-        p3 = re.compile(r'^(?P<tunnel_id>\d+)\s+(?P<local_ip>[\w.]+)/(?P<local_port>\d+)\s+(?P<remote_ip>[\w.]+)/(?P<remote_port>\d+)\s+(?P<fvrf>\w+)/(?P<ivrf>\w+)\s+(?P<status>[\w]+)$')
+        p3 = re.compile(r'^(?P<tunnel_id>\d+)\s+(?P<local_ip>[\w.]+)/(?P<local_port>\d+)\s+(?P<remote_ip>[\w.]+)/(?P<remote_port>\d+)\s+(?P<fvrf>\w+)/(?P<ivrf>\w+)\s+(?P<status>\w+)$')
 
         # Encr: AES-CBC, keysize: 128, PRF: SHA1, Hash: SHA96, DH Grp:16, Auth sign: PSK, Auth verify: PSK
         p4 = re.compile(r'^Encr:\s*(?P<encryption>[\w-]+),\s*keysize:\s*(?P<keysize>\d+),\s*PRF:\s*(?P<prf>\w+),\s*Hash:\s*(?P<hash>\w+),\s*DH Grp:(?P<dh_group>\d+),\s*Auth sign:\s*(?P<auth_sign>\w+),\s*Auth verify:\s*(?P<auth_verify>\w+)')


### PR DESCRIPTION
For Cat8000v - The output for the command "show crypto ikev2 sa"  has double spaces as illustrated in device output below for IPv3 Crypto IKEv2  SA




Fixed p1 = re.compile statement to include one or more spaces between IKEv2 and SA text output. Fixed p3 = re.compile statement to assume a single \w or more for Status.

## Description
The output for the command "show crypto ikev2 sa"  has double spaces as illustrated in device output below for IPv3 Crypto IKEv2  SA

## Motivation and Context
Support of command on Cat 8000 v platform

## Impact (If any)
None

## Screenshots:
```
Router01#sh crypto ikev2 sa
 IPv4 Crypto IKEv2  SA 

Tunnel-id Local                 Remote                fvrf/ivrf            Status 
4         1.1.54.101/500     1.1.167.93/500     Internet_vrf/cust1   READY  
      Encr: AES-CBC, keysize: 256, PRF: SHA384, Hash: SHA384, DH Grp:19, Auth sign: PSK, Auth verify: PSK
      Life/Active Time: 86400/4928 sec
```


## Checklist:
<!--- This is meant more as a personal checklist so we don't forgot important steps! -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] I have updated the changelog.
- [] I have updated the documentation (If applicable).
- [] I have added tests to cover my changes (If applicable).
- [] All new and existing tests passed.
- [] All new code passed compilation.
